### PR TITLE
Enable Renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,6 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:best-practices"],
+  automerge: true,
+  platformAutomerge: false,
+}


### PR DESCRIPTION
## Summary
- Convert the Renovate config to `renovate.json5`.
- Enable Renovate automerge while disabling platform-native automerge.

## Why
This lets Renovate merge passing dependency update PRs itself instead of handing merge timing to GitHub platform automerge.

## Validation
- `gofmt -l .`
- `go test -v ./...`
- `go build -o tfmr`
- `npx --yes --package renovate renovate-config-validator --strict renovate.json5`