### PR TITLE
Support immutable releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*'
 
 permissions:
   contents: write
@@ -12,6 +12,23 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate release tag
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tags must be full semver tags like v1.2.3. Moving action tags such as v1 must not create GitHub Releases."
+            exit 1
+          fi
+
+      - name: Ensure published release does not already exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          release_draft="$(gh release view "${GITHUB_REF_NAME}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
+          if [ "${release_draft}" = "false" ]; then
+            echo "::error::GitHub Release ${GITHUB_REF_NAME} already exists. Immutable releases cannot be republished; cut a new version tag."
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A CLI tool to analyze Terraform modules and list all related files, including fi
 Pin to a specific version:
 
 ```yaml
-- uses: mkusaka/tfmr@v0
+- uses: mkusaka/tfmr@v1.2.3
   with:
     version: v1.2.3
 ```
@@ -189,6 +189,14 @@ Use the release script to bump the version and trigger the release workflow:
 ```
 
 The script creates and pushes a git tag, which triggers GitHub Actions to build binaries for all platforms via [goreleaser](https://goreleaser.com) and publish a GitHub Release.
+
+Only full semantic version tags (`vX.Y.Z`) are published as GitHub Releases. The script also updates the moving major action tag (`vX`) so workflows can use refs such as `mkusaka/tfmr@v0`, but that tag is intentionally kept as a tag-only ref and must not have a GitHub Release attached to it. This keeps release-specific tags immutable while preserving the normal GitHub Action major-version ref.
+
+After this workflow is merged, enable release immutability for the repository in GitHub settings or with:
+
+```bash
+gh api -X PUT repos/mkusaka/tfmr/immutable-releases
+```
 
 ## License
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -47,14 +47,38 @@ if [ -n "$(git status --porcelain)" ]; then
   exit 1
 fi
 
-# Check tag doesn't already exist
-if git rev-parse "${tag}" >/dev/null 2>&1; then
+# Check release tag doesn't already exist locally or remotely
+if git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
   echo "Error: tag '${tag}' already exists"
   exit 1
 fi
+remote_tag="$(git ls-remote --tags origin "refs/tags/${tag}")"
+if [ -n "${remote_tag}" ]; then
+  echo "Error: remote tag '${tag}' already exists"
+  exit 1
+fi
+if command -v gh >/dev/null 2>&1; then
+  release_draft="$(gh release view "${tag}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
+  if [ "${release_draft}" = "false" ]; then
+    echo "Error: GitHub Release '${tag}' already exists"
+    exit 1
+  fi
+fi
+
+release_version="${tag#v}"
+IFS='.' read -r release_major _release_minor _release_patch <<< "${release_version}"
+major_tag="v${release_major}"
+
+if command -v gh >/dev/null 2>&1; then
+  major_release_draft="$(gh release view "${major_tag}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
+  if [ -n "${major_release_draft}" ]; then
+    echo "Error: GitHub Release '${major_tag}' exists"
+    echo "Moving action tags such as '${major_tag}' must not have GitHub Releases when release immutability is enabled."
+    exit 1
+  fi
+fi
 
 # Show what will be released
-major_tag="${tag%%.*}"
 if [ -n "${latest:-}" ]; then
   echo "${latest} -> ${tag} (${arg})"
 else
@@ -62,6 +86,7 @@ else
 fi
 echo "Commit: $(git log --oneline -1)"
 echo "Branch: $(git branch --show-current)"
+echo "Moving action tag: ${major_tag} -> ${tag}"
 echo ""
 read -rp "Proceed? [y/N] " confirm
 if [ "${confirm}" != "y" ] && [ "${confirm}" != "Y" ]; then
@@ -72,10 +97,14 @@ fi
 git tag "${tag}"
 git push origin "${tag}"
 
+release_commit="$(git rev-parse "${tag}^{commit}")"
+git tag -f "${major_tag}" "${release_commit}"
+git push --force origin "refs/tags/${major_tag}"
+
 echo ""
 echo "Tag '${tag}' pushed. GitHub Actions will:"
 echo "  1. Build binaries for 5 platforms via goreleaser"
 echo "  2. Create GitHub Release with assets"
-echo "  3. Update major version tag (${major_tag})"
+echo "  3. Leave the moving major tag (${major_tag}) as a tag-only action ref"
 echo ""
 echo "Monitor: https://github.com/mkusaka/tfmr/actions"


### PR DESCRIPTION
## Summary
- Restrict the release workflow to full semantic version tags only.
- Add guards against republishing existing published releases.
- Update the release script to keep the major action tag as a tag-only moving ref.
- Document the immutable release setup command and pinning behavior.

## Verification
- bash -n scripts/release.sh
- shellcheck scripts/release.sh
- actionlint .github/workflows/release.yaml
- goreleaser check
- go test ./...
- git diff --check

## Notes
- GitHub release immutability is not enabled by this PR; it must be enabled after merge with .