### PR TITLE
Pin GoReleaser CLI version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace the GoReleaser action CLI version input from `latest` to `~> v2`.
- Match the current GoReleaser action documentation and remove the release workflow warning.

## Verification
- actionlint .github/workflows/release.yaml
- goreleaser check

## Reference
- https://goreleaser.com/customization/ci/actions/